### PR TITLE
Feat/contracts

### DIFF
--- a/src/apps/api/modules/cars/cars.controller.ts
+++ b/src/apps/api/modules/cars/cars.controller.ts
@@ -44,11 +44,13 @@ export class CarsController {
   }
 
   @Get()
-  @ApiResponse({ type: GetCarsQuery.Response, isArray: true })
-  async getCars(): Promise<GetCarsQuery.Response[]> {
+  @ApiResponse({ type: GetCarsQuery.Response })
+  async getCars(): Promise<GetCarsQuery.Response> {
     const cars = await this._getCarsUseCase.execute();
 
-    return cars.map((car) => ({ ...car }));
+    return {
+      cars: cars.map((car) => ({ ...car })),
+    };
   }
 
   @Delete(':id')
@@ -59,7 +61,7 @@ export class CarsController {
   }
 
   @Post('/:id/ride')
-  @ApiResponse({ type: RideCarCommand.Request })
+  @ApiResponse({ type: RideCarCommand.Response })
   async rideCar(
     @Param('id', new ParseUUIDPipe()) id: RideCarCommand.Request['id'],
   ): Promise<RideCarCommand.Response> {

--- a/src/apps/api/modules/cars/cars.controller.ts
+++ b/src/apps/api/modules/cars/cars.controller.ts
@@ -8,7 +8,6 @@ import {
   ParseUUIDPipe,
   Post,
 } from '@nestjs/common';
-import { CarResponseDTO, CreateCarDTO } from './dto';
 import {
   ICreateCarUseCase,
   IDeleteCarUseCase,
@@ -16,6 +15,12 @@ import {
   IRideCarUseCase,
 } from '@interfaces/use-cases/cars';
 import { ApiResponse } from '@nestjs/swagger';
+import {
+  CreateCarCommand,
+  GetCarsQuery,
+  DeleteCarCommand,
+  RideCarCommand,
+} from '@shared/contracts';
 
 @Controller('cars')
 export class CarsController {
@@ -29,30 +34,37 @@ export class CarsController {
   ) {}
 
   @Post()
-  @ApiResponse({ type: CarResponseDTO })
-  async createCar(@Body() carDto: CreateCarDTO): Promise<CarResponseDTO> {
-    const car = await this._createCarUseCase.execute({ model: carDto.model });
+  @ApiResponse({ type: CreateCarCommand.Response })
+  async createCar(
+    @Body() request: CreateCarCommand.Request,
+  ): Promise<CreateCarCommand.Response> {
+    const car = await this._createCarUseCase.execute({ model: request.model });
+
     return { ...car };
   }
 
   @Get()
-  @ApiResponse({ type: CarResponseDTO, isArray: true })
-  async getCars(): Promise<CarResponseDTO[]> {
+  @ApiResponse({ type: GetCarsQuery.Response, isArray: true })
+  async getCars(): Promise<GetCarsQuery.Response[]> {
     const cars = await this._getCarsUseCase.execute();
+
     return cars.map((car) => ({ ...car }));
   }
 
   @Delete(':id')
-  async deleteCar(@Param('id', new ParseUUIDPipe()) id: string): Promise<void> {
+  async deleteCar(
+    @Param('id', new ParseUUIDPipe()) id: DeleteCarCommand.Request['id'],
+  ): Promise<void> {
     await this._deleteCarUseCae.execute({ id });
   }
 
   @Post('/:id/ride')
-  @ApiResponse({ type: CarResponseDTO })
+  @ApiResponse({ type: RideCarCommand.Request })
   async rideCar(
-    @Param('id', new ParseUUIDPipe()) id: string,
-  ): Promise<CarResponseDTO> {
+    @Param('id', new ParseUUIDPipe()) id: RideCarCommand.Request['id'],
+  ): Promise<RideCarCommand.Response> {
     const car = await this._rideCarUseCase.execute({ id });
+
     return {
       ...car,
     };

--- a/src/shared/contracts/cars/cars.base-response.ts
+++ b/src/shared/contracts/cars/cars.base-response.ts
@@ -1,0 +1,18 @@
+import { TCarModel } from '@infra/database/schemas';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsPositive, IsString } from 'class-validator';
+
+export class CarBaseResponse {
+  @ApiProperty({ description: 'Car id' })
+  @IsString()
+  id: TCarModel['id'];
+
+  @ApiProperty({ description: 'Car model' })
+  @IsString()
+  model: TCarModel['model'];
+
+  @ApiProperty({ description: 'Amount of rides that car made' })
+  @IsInt()
+  @IsPositive()
+  ridesCount: TCarModel['ridesCount'];
+}

--- a/src/shared/contracts/cars/cars.create-car.command.ts
+++ b/src/shared/contracts/cars/cars.create-car.command.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { CarBaseResponse } from './cars.base-response';
+import { TCarModel } from '@infra/database/schemas';
+
+export namespace CreateCarCommand {
+  export class Request {
+    @ApiProperty()
+    @IsNotEmpty()
+    @IsString()
+    model: TCarModel['model'];
+  }
+
+  export class Response extends CarBaseResponse {}
+}

--- a/src/shared/contracts/cars/cars.delete-car.command.ts
+++ b/src/shared/contracts/cars/cars.delete-car.command.ts
@@ -1,0 +1,12 @@
+import { TCarModel } from '@infra/database/schemas';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export namespace DeleteCarCommand {
+  export class Request {
+    @ApiProperty()
+    @IsNotEmpty()
+    @IsString()
+    id: TCarModel['id'];
+  }
+}

--- a/src/shared/contracts/cars/cars.get-cars.query.ts
+++ b/src/shared/contracts/cars/cars.get-cars.query.ts
@@ -1,0 +1,5 @@
+import { CarBaseResponse } from './cars.base-response';
+
+export namespace GetCarsQuery {
+  export class Response extends CarBaseResponse {}
+}

--- a/src/shared/contracts/cars/cars.get-cars.query.ts
+++ b/src/shared/contracts/cars/cars.get-cars.query.ts
@@ -1,5 +1,7 @@
 import { CarBaseResponse } from './cars.base-response';
 
 export namespace GetCarsQuery {
-  export class Response extends CarBaseResponse {}
+  export class Response {
+    cars: CarBaseResponse[];
+  }
 }

--- a/src/shared/contracts/cars/cars.ride-car.command.ts
+++ b/src/shared/contracts/cars/cars.ride-car.command.ts
@@ -1,0 +1,15 @@
+import { TCarModel } from '@infra/database/schemas';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { CarBaseResponse } from './cars.base-response';
+
+export namespace RideCarCommand {
+  export class Request {
+    @ApiProperty()
+    @IsNotEmpty()
+    @IsString()
+    id: TCarModel['id'];
+  }
+
+  export class Response extends CarBaseResponse {}
+}

--- a/src/shared/contracts/index.ts
+++ b/src/shared/contracts/index.ts
@@ -1,0 +1,4 @@
+export * from './cars/cars.create-car.command';
+export * from './cars/cars.get-cars.query';
+export * from './cars/cars.delete-car.command';
+export * from './cars/cars.ride-car.command';


### PR DESCRIPTION
`DTO` only for internal usage, for example Controller → Service. For external usage, we should use `Request`/`Response`, to maintain backward compatibility. 

With this pattern, you actually can easily migrate to Microservices + CQRS in the future.